### PR TITLE
Add options to the GKE cluster

### DIFF
--- a/iap-connector.py
+++ b/iap-connector.py
@@ -28,7 +28,7 @@ def GenerateConfig(context):
       '-v1beta1-rbac-authorization': 'apis/rbac.authorization.k8s.io/v1beta1'
   }
 
-  resources = [{
+  cluster = {
       'name': cluster_name,
       'type': 'container.v1.cluster',
       'properties': {
@@ -39,6 +39,8 @@ def GenerateConfig(context):
               'initialNodeCount':
                   context.properties['initialNodeCount'],
               'nodeConfig': {
+                  'machineType': context.properties['machineType'],
+                  'preemptible': context.properties['preemptible'],
                   'oauthScopes': [
                       'https://www.googleapis.com/auth/' + s for s in [
                           'compute', 'devstorage.read_only', 'logging.write',
@@ -48,7 +50,14 @@ def GenerateConfig(context):
               }
           }
       }
-  }]
+  }
+
+  if context.properties['network'] is not None:
+      cluster['properties']['cluster']['network'] = context.properties['network']
+  if context.properties['subnetwork'] is not None:
+      cluster['properties']['cluster']['subnetwork'] = context.properties['subnetwork']
+
+  resources = [cluster]
 
   k8s_resource_types = []
   k8s_resource_types.append(service_type_name)

--- a/iap-connector.py
+++ b/iap-connector.py
@@ -28,7 +28,7 @@ def GenerateConfig(context):
       '-v1beta1-rbac-authorization': 'apis/rbac.authorization.k8s.io/v1beta1'
   }
 
-  cluster = {
+  resources = [{
       'name': cluster_name,
       'type': 'container.v1.cluster',
       'properties': {
@@ -36,6 +36,8 @@ def GenerateConfig(context):
           'cluster': {
               'name':
                   cluster_name,
+              'network': context.properties['network'],
+              'subnetwork': context.properties['subnetwork'],
               'initialNodeCount':
                   context.properties['initialNodeCount'],
               'nodeConfig': {
@@ -50,14 +52,7 @@ def GenerateConfig(context):
               }
           }
       }
-  }
-
-  if context.properties['network'] is not None:
-      cluster['properties']['cluster']['network'] = context.properties['network']
-  if context.properties['subnetwork'] is not None:
-      cluster['properties']['cluster']['subnetwork'] = context.properties['subnetwork']
-
-  resources = [cluster]
+  }]
 
   k8s_resource_types = []
   k8s_resource_types.append(service_type_name)

--- a/iap-connector.py.schema
+++ b/iap-connector.py.schema
@@ -42,10 +42,24 @@ properties:
     type: string
     description: Ambassador image version to run.
     default: 0.39.0
+  network:
+    type: string
+    description: Name of the network in which to run the cluster.
+  subnetwork:
+    type: string
+    description: Name of the subnetwork in which to run the cluster.
   replicas:
     type: integer
     description: Initial number of replica for ambassador deployment.
     default: 3
+  machineType:
+    type: string
+    description: The machine type to use for cluster nodes.
+    default: n1-standard-1
+  preemptible:
+    type: boolean
+    description: Whether or not to use preemptible VMs for the cluster.
+    default: false
   routing:
     type: array
     description: Routing maps

--- a/iap-connector.py.schema
+++ b/iap-connector.py.schema
@@ -45,9 +45,11 @@ properties:
   network:
     type: string
     description: Name of the network in which to run the cluster.
+    default: default
   subnetwork:
     type: string
     description: Name of the subnetwork in which to run the cluster.
+    default: default
   replicas:
     type: integer
     description: Initial number of replica for ambassador deployment.


### PR DESCRIPTION
This allows to specify the machine type to use,
whether to use preemptible VMs or not, and most
importantly the VPC and subnet in which to create
the cluster.

On-prem connectivity is often not done in the default
VPC because on-prem connectivity often requires specific
IP ranges to be used.