### PR TITLE
Remove node_config parameter from google_container_cluster

### DIFF
--- a/terraform-and-helm/iap-connector/terraform/modules/gke-cluster/main.tf
+++ b/terraform-and-helm/iap-connector/terraform/modules/gke-cluster/main.tf
@@ -48,28 +48,6 @@ resource "google_container_cluster" "private-gke" {
 
   initial_node_count = 1
 
-  node_config {
-    service_account = "${google_service_account.gke_node.email}"
-
-    #service_account = "serviceAccount:${google_service_account.gke_node.email}"
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/compute",
-      "https://www.googleapis.com/auth/devstorage.read_write",
-      "https://www.googleapis.com/auth/projecthosting",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
-
-    metadata {
-      disable-legacy-endpoints = "true"
-    }
-
-    machine_type = "${var.gke_nodes_machine_type}"
-    disk_type    = "${var.gke_nodes_disk_type}"
-    disk_size_gb = "${var.gke_nodes_disk_size_gb}"
-    tags         = "${var.gke_node_tags}"
-  }
-
   addons_config {
     horizontal_pod_autoscaling {
       disabled = "${var.disable_horizontal_pod_autoscaling}"


### PR DESCRIPTION
Removed optional node_config parameter from google_container_cluster to prevent TF from deleting cluster on updates to machine type vars. Configuration should be managed exclusively in google_container_node_pool[1], otherwise updating the machine type vars results in a cluster deletion and rebuild.

[1] https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_config