### PR TITLE
Update iap-connector.yaml

### DIFF
--- a/deployment-manager-shared-vpc/iap-connector.yaml
+++ b/deployment-manager-shared-vpc/iap-connector.yaml
@@ -12,8 +12,8 @@ resources:
   properties:
     zone: <ZONE>
     serviceAccountName: <PROJECT_NUMBER>@cloudservices.gserviceaccount.com
-    network: projects/<HOST PROJECT>/global/networks/<NETWORK NAME>
-    subnetwork: projects/<HOST PROJECT>/regions/<REGION>/subnetworks/<SUBNET>
+    network: <NETWORK NAME>
+    subnetwork: <SUBNET NAME>
     useIpAliases: True
     clusterSecondaryRangeName: <CLUSTER SECONDARY RANGE NAME>
     servicesSecondaryRangeName: <SERVICES SECONDARY RANGE NAME>


### PR DESCRIPTION
The deployment fails when using full resource names for variables "resources[].properties.network" and "resources[].properties.subnetwork". Just the network and the subnetwork name needs to be added in order to deploy the IAP connector successfully.